### PR TITLE
Fix installation of opencv, add git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ WORKDIR /home
 
 COPY requirements.txt /home
 
+RUN pip3 install --upgrade pip
 RUN pip3 install --trusted-host pypi.python.org -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -y 
-RUN apt-get -y install mingw-w64 build-essential srecord python3 python3-pip
+RUN apt-get -y install mingw-w64 build-essential srecord python3 python3-pip git
 
 WORKDIR /home
 


### PR DESCRIPTION
OpenCV was failing to install as a result of an outdated version of pip.

Git may be useful as part of the emulator build process, so I've added it (came up during a bit of refactoring I was doing). 